### PR TITLE
Abort program if either background task fails

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -324,6 +324,10 @@ async fn ruuvi_emitter(
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt::init();
+    let addr = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "0.0.0.0:9185".to_string());
+    let address: SocketAddr = addr.parse()?;
 
     let manager = Manager::new().await?;
 
@@ -332,7 +336,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let central = get_central(&manager).await?;
 
     let (tx, rx) = mpsc::channel(100);
-    let address: SocketAddr = "0.0.0.0:9185".parse()?;
 
     // Tasks we want to clean up when we're done.
     let to_kill = vec![

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,16 +29,16 @@ fn from_manuf(manufacturer_data: HashMap<u16, Vec<u8>>) -> Option<SensorValues> 
 }
 
 mod prom {
-    use lazy_static::lazy_static;
-    use tokio::sync::mpsc;
-    use std::collections::HashMap;
     use btleplug::api::BDAddr;
+    use lazy_static::lazy_static;
     use prometheus::{self, GaugeVec, IntCounterVec, IntGaugeVec};
     use prometheus::{
         labels, opts, register_gauge_vec, register_int_counter_vec, register_int_gauge_vec,
     };
     use ruuvi_sensor_protocol::SensorValues;
     use ruuvi_sensor_protocol::{MacAddress, MeasurementSequenceNumber};
+    use std::collections::HashMap;
+    use tokio::sync::mpsc;
     use tracing::{info, span, warn, Level};
 
     lazy_static! {
@@ -96,11 +96,11 @@ mod prom {
     }
 
     fn register_sensor(sensor: &SensorValues) {
-        use tracing::field;
         use ruuvi_sensor_protocol::{
             Acceleration, BatteryPotential, Humidity, MovementCounter, Pressure, Temperature,
             TransmitterPower,
         };
+        use tracing::field;
         // It is important that the keys in the span match what we use in `span.record("key",...)` below.
         let span = span!(
             Level::INFO,


### PR DESCRIPTION
This uses select!  instead of a try-join that would let background
threads fail and the program continue anyhow.

This was easiest to notice if the socket was already bound, as the
exporter would keep running even as it was unable to serve any data.

Now instead it properly fails and terminates cleanly, although maybe not
signalling failure exit code.